### PR TITLE
Add transition with phantom types

### DIFF
--- a/src/Css.elm
+++ b/src/Css.elm
@@ -518,6 +518,117 @@ module Css exposing
     , strokeLinejoin, strokeLinejoin2, crop, arcs, miter, bevel
     , strokeDashJustify, compress, dashes, gaps
 
+    -- Transitions
+    , AnimatableSupported
+    , Animatable
+    , TransitionBehaviorSupported
+    , TransitionBehavior
+    , TransitionConfig
+    , defaultTransition
+    , transition
+    , transitionMany
+    , transitionProperty
+    , transitionDuration
+    , transitionDelay
+    , transitionTimingFunction
+    , transitionBehavior
+    , background_
+    , backgroundColor_
+    , backgroundPosition_
+    , backgroundSize_
+    , border_
+    , borderBottom_
+    , borderBottomColor_
+    , borderBottomLeftRadius_
+    , borderBottomRightRadius_
+    , borderBottomWidth_
+    , borderColor_
+    , borderLeft_
+    , borderLeftColor_
+    , borderLeftWidth_
+    , borderRadius_
+    , borderRight_
+    , borderRightColor_
+    , borderRightWidth_
+    , borderTop_
+    , borderTopColor_
+    , borderTopLeftRadius_
+    , borderTopRightRadius_
+    , borderTopWidth_
+    , borderWidth_
+    , bottom_
+    , boxShadow_
+    , caretColor_
+    , clip_
+    , clipPath_
+    , color_
+    , columnCount_
+    , columnGap_
+    , columnRule_
+    , columnRuleColor_
+    , columnRuleWidth_
+    , columnWidth_
+    , columns_
+    , filter_
+    , flex_
+    , flexBasis_
+    , flexGrow_
+    , flexShrink_
+    , font_
+    , fontSize_
+    , fontSizeAdjust_
+    , fontStretch_
+    , fontVariationSettings_
+    , fontWeight_
+    , gridColumnGap_
+    , gridGap_
+    , gridRowGap_
+    , height_
+    , left_
+    , letterSpacing_
+    , lineHeight_
+    , margin_
+    , marginBottom_
+    , marginLeft_
+    , marginRight_
+    , marginTop_
+    , mask_
+    , maskPosition_
+    , maskSize_
+    , maxHeight_
+    , maxWidth_
+    , minHeight_
+    , minWidth_
+    , objectPosition_
+    , offset_
+    , offsetAnchor_
+    , offsetDistance_
+    , offsetPath_
+    , offsetRotate_
+    , opacity_
+    , order_
+    , outline_
+    , outlineColor_
+    , outlineOffset_
+    , outlineWidth_
+    , padding_
+    , paddingBottom_
+    , paddingLeft_
+    , paddingRight_
+    , paddingTop_
+    , right_
+    , tabSize_
+    , textIndent_
+    , textShadow_
+    , top_
+    , transform_
+    , transformOrigin_
+    , verticalAlign_
+    , visibility_
+    , width_
+    , wordSpacing_
+    , zIndex_
+
     -- WebKit stuff that's standardised for legacy support
     , lineClamp
     )
@@ -20774,7 +20885,7 @@ defaultBoxShadow =
 
     boxShadow none
 
-For defining shadows look at [`boxShadowsMany`](#boxShadowsMany).
+For defining shadows look at [`boxShadowMany`](#boxShadowMany).
 
 -}
 boxShadow : BaseValue { none : Supported } -> Style
@@ -24504,6 +24615,689 @@ dashes =
 gaps : Value { provides | gaps : Supported }
 gaps =
     Value "gaps"
+
+
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+----------------------------- TRANSITIONS ------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+
+
+type alias AnimatableSupported supported =
+    { supported
+        | all : Supported
+        , background_ : Supported
+        , backgroundColor_ : Supported
+        , backgroundPosition_ : Supported
+        , backgroundSize_ : Supported
+        , border_ : Supported
+        , borderBottom_ : Supported
+        , borderBottomColor_ : Supported
+        , borderBottomLeftRadius_ : Supported
+        , borderBottomRightRadius_ : Supported
+        , borderBottomWidth_ : Supported
+        , borderColor_ : Supported
+        , borderLeft_ : Supported
+        , borderLeftColor_ : Supported
+        , borderLeftWidth_ : Supported
+        , borderRadius_ : Supported
+        , borderRight_ : Supported
+        , borderRightColor_ : Supported
+        , borderRightWidth_ : Supported
+        , borderTop_ : Supported
+        , borderTopColor_ : Supported
+        , borderTopLeftRadius_ : Supported
+        , borderTopRightRadius_ : Supported
+        , borderTopWidth_ : Supported
+        , borderWidth_ : Supported
+        , bottom_ : Supported
+        , boxShadow_ : Supported
+        , caretColor_ : Supported
+        , clip_ : Supported
+        , clipPath_ : Supported
+        , color_ : Supported
+        , columnCount_ : Supported
+        , columnGap_ : Supported
+        , columnRule_ : Supported
+        , columnRuleColor_ : Supported
+        , columnRuleWidth_ : Supported
+        , columnWidth_ : Supported
+        , columns_ : Supported
+        , filter_ : Supported
+        , flex_ : Supported
+        , flexBasis_ : Supported
+        , flexGrow_ : Supported
+        , flexShrink_ : Supported
+        , font_ : Supported
+        , fontSize_ : Supported
+        , fontSizeAdjust_ : Supported
+        , fontStretch_ : Supported
+        , fontVariationSettings_ : Supported
+        , fontWeight_ : Supported
+        , gridColumnGap_ : Supported
+        , gridGap_ : Supported
+        , gridRowGap_ : Supported
+        , height_ : Supported
+        , left_ : Supported
+        , letterSpacing_ : Supported
+        , lineHeight_ : Supported
+        , margin_ : Supported
+        , marginBottom_ : Supported
+        , marginLeft_ : Supported
+        , marginRight_ : Supported
+        , marginTop_ : Supported
+        , mask_ : Supported
+        , maskPosition_ : Supported
+        , maskSize_ : Supported
+        , maxHeight_ : Supported
+        , maxWidth_ : Supported
+        , minHeight_ : Supported
+        , minWidth_ : Supported
+        , objectPosition_ : Supported
+        , offset_ : Supported
+        , offsetAnchor_ : Supported
+        , offsetDistance_ : Supported
+        , offsetPath_ : Supported
+        , offsetRotate_ : Supported
+        , opacity_ : Supported
+        , order_ : Supported
+        , outline_ : Supported
+        , outlineColor_ : Supported
+        , outlineOffset_ : Supported
+        , outlineWidth_ : Supported
+        , padding_ : Supported
+        , paddingBottom_ : Supported
+        , paddingLeft_ : Supported
+        , paddingRight_ : Supported
+        , paddingTop_ : Supported
+        , right_ : Supported
+        , tabSize_ : Supported
+        , textIndent_ : Supported
+        , textShadow_ : Supported
+        , top_ : Supported
+        , transform_ : Supported
+        , transformOrigin_ : Supported
+        , verticalAlign_ : Supported
+        , visibility_ : Supported
+        , width_ : Supported
+        , wordSpacing_ : Supported
+        , zIndex_ : Supported
+    }
+
+
+type alias Animatable =
+    AnimatableSupported {}
+
+
+background_ : Value { provided | background_ : Supported }
+background_ =
+    Value "background"
+
+
+backgroundColor_ : Value { provided | backgroundColor_ : Supported }
+backgroundColor_ =
+    Value "background-color"
+
+
+backgroundPosition_ : Value { provided | backgroundPosition_ : Supported }
+backgroundPosition_ =
+    Value "background-position"
+
+
+backgroundSize_ : Value { provided | backgroundSize_ : Supported }
+backgroundSize_ =
+    Value "background-size"
+
+
+border_ : Value { provided | border_ : Supported }
+border_ =
+    Value "border"
+
+
+borderBottom_ : Value { provided | borderBottom_ : Supported }
+borderBottom_ =
+    Value "border-bottom"
+
+
+borderBottomColor_ : Value { provided | borderBottomColor_ : Supported }
+borderBottomColor_ =
+    Value "border-bottom-color"
+
+
+borderBottomLeftRadius_ : Value { provided | borderBottomLeftRadius_ : Supported }
+borderBottomLeftRadius_ =
+    Value "border-bottom-left-radius"
+
+
+borderBottomRightRadius_ : Value { provided | borderBottomRightRadius_ : Supported }
+borderBottomRightRadius_ =
+    Value "border-bottom-right-radius"
+
+
+borderBottomWidth_ : Value { provided | borderBottomWidth_ : Supported }
+borderBottomWidth_ =
+    Value "border-bottom-width"
+
+
+borderColor_ : Value { provided | borderColor_ : Supported }
+borderColor_ =
+    Value "border-color"
+
+
+borderLeft_ : Value { provided | borderLeft_ : Supported }
+borderLeft_ =
+    Value "border-left"
+
+
+borderLeftColor_ : Value { provided | borderLeftColor_ : Supported }
+borderLeftColor_ =
+    Value "border-left-color"
+
+
+borderLeftWidth_ : Value { provided | borderLeftWidth_ : Supported }
+borderLeftWidth_ =
+    Value "border-left-width"
+
+
+borderRadius_ : Value { provided | borderRadius_ : Supported }
+borderRadius_ =
+    Value "border-radius"
+
+
+borderRight_ : Value { provided | borderRight_ : Supported }
+borderRight_ =
+    Value "border-right"
+
+
+borderRightColor_ : Value { provided | borderRightColor_ : Supported }
+borderRightColor_ =
+    Value "border-right-color"
+
+
+borderRightWidth_ : Value { provided | borderRightWidth_ : Supported }
+borderRightWidth_ =
+    Value "border-right-width"
+
+
+borderTop_ : Value { provided | borderTop_ : Supported }
+borderTop_ =
+    Value "border-top"
+
+
+borderTopColor_ : Value { provided | borderTopColor_ : Supported }
+borderTopColor_ =
+    Value "border-top-color"
+
+
+borderTopLeftRadius_ : Value { provided | borderTopLeftRadius_ : Supported }
+borderTopLeftRadius_ =
+    Value "border-top-left-radius"
+
+
+borderTopRightRadius_ : Value { provided | borderTopRightRadius_ : Supported }
+borderTopRightRadius_ =
+    Value "border-top-right-radius"
+
+
+borderTopWidth_ : Value { provided | borderTopWidth_ : Supported }
+borderTopWidth_ =
+    Value "border-top-width"
+
+
+borderWidth_ : Value { provided | borderWidth_ : Supported }
+borderWidth_ =
+    Value "border-width"
+
+
+boxShadow_ : Value { provided | boxShadow_ : Supported }
+boxShadow_ =
+    Value "box-shadow"
+
+
+caretColor_ : Value { provided | caretColor_ : Supported }
+caretColor_ =
+    Value "caret-color"
+
+
+clip_ : Value { provided | clip_ : Supported }
+clip_ =
+    Value "clip"
+
+
+clipPath_ : Value { provided | clipPath_ : Supported }
+clipPath_ =
+    Value "clip-path"
+
+
+columnCount_ : Value { provided | columnCount_ : Supported }
+columnCount_ =
+    Value "column-count"
+
+
+columnGap_ : Value { provided | columnGap_ : Supported }
+columnGap_ =
+    Value "column-gap"
+
+
+columnRule_ : Value { provided | columnRule_ : Supported }
+columnRule_ =
+    Value "column-rule"
+
+
+columnRuleColor_ : Value { provided | columnRuleColor_ : Supported }
+columnRuleColor_ =
+    Value "column-rule-color"
+
+
+columnRuleWidth_ : Value { provided | columnRuleWidth_ : Supported }
+columnRuleWidth_ =
+    Value "column-rule-width"
+
+
+columnWidth_ : Value { provided | columnWidth_ : Supported }
+columnWidth_ =
+    Value "column-width"
+
+
+columns_ : Value { provided | columns_ : Supported }
+columns_ =
+    Value "columns"
+
+
+filter_ : Value { provided | filter_ : Supported }
+filter_ =
+    Value "filter"
+
+
+flexBasis_ : Value { provided | flexBasis_ : Supported }
+flexBasis_ =
+    Value "flex-basis"
+
+
+flexGrow_ : Value { provided | flexGrow_ : Supported }
+flexGrow_ =
+    Value "flex-grow"
+
+
+flexShrink_ : Value { provided | flexShrink_ : Supported }
+flexShrink_ =
+    Value "flex-shrink"
+
+
+font_ : Value { provided | font_ : Supported }
+font_ =
+    Value "font"
+
+
+fontSize_ : Value { provided | fontSize_ : Supported }
+fontSize_ =
+    Value "font-size"
+
+
+fontSizeAdjust_ : Value { provided | fontSizeAdjust_ : Supported }
+fontSizeAdjust_ =
+    Value "font-size-adjust"
+
+
+fontStretch_ : Value { provided | fontStretch_ : Supported }
+fontStretch_ =
+    Value "font-stretch"
+
+
+fontVariationSettings_ : Value { provided | fontVariationSettings_ : Supported }
+fontVariationSettings_ =
+    Value "font-variation-settings"
+
+
+fontWeight_ : Value { provided | fontWeight_ : Supported }
+fontWeight_ =
+    Value "font-weight"
+
+
+gridColumnGap_ : Value { provided | gridColumnGap_ : Supported }
+gridColumnGap_ =
+    Value "grid-column-gap"
+
+
+gridGap_ : Value { provided | gridGap_ : Supported }
+gridGap_ =
+    Value "grid-gap"
+
+
+gridRowGap_ : Value { provided | gridRowGap_ : Supported }
+gridRowGap_ =
+    Value "grid-row-gap"
+
+
+height_ : Value { provided | height_ : Supported }
+height_ =
+    Value "height"
+
+
+letterSpacing_ : Value { provided | letterSpacing_ : Supported }
+letterSpacing_ =
+    Value "letter-spacing"
+
+
+lineHeight_ : Value { provided | lineHeight_ : Supported }
+lineHeight_ =
+    Value "line-height"
+
+
+margin_ : Value { provided | margin_ : Supported }
+margin_ =
+    Value "margin"
+
+
+marginBottom_ : Value { provided | marginBottom_ : Supported }
+marginBottom_ =
+    Value "margin-bottom"
+
+
+marginLeft_ : Value { provided | marginLeft_ : Supported }
+marginLeft_ =
+    Value "margin-left"
+
+
+marginRight_ : Value { provided | marginRight_ : Supported }
+marginRight_ =
+    Value "margin-right"
+
+
+marginTop_ : Value { provided | marginTop_ : Supported }
+marginTop_ =
+    Value "margin-top"
+
+
+mask_ : Value { provided | mask_ : Supported }
+mask_ =
+    Value "mask"
+
+
+maskPosition_ : Value { provided | maskPosition_ : Supported }
+maskPosition_ =
+    Value "mask-position"
+
+
+maskSize_ : Value { provided | maskSize_ : Supported }
+maskSize_ =
+    Value "mask-size"
+
+
+maxHeight_ : Value { provided | maxHeight_ : Supported }
+maxHeight_ =
+    Value "max-height"
+
+
+maxWidth_ : Value { provided | maxWidth_ : Supported }
+maxWidth_ =
+    Value "max-width"
+
+
+minHeight_ : Value { provided | minHeight_ : Supported }
+minHeight_ =
+    Value "min-height"
+
+
+minWidth_ : Value { provided | minWidth_ : Supported }
+minWidth_ =
+    Value "min-width"
+
+
+objectPosition_ : Value { provided | objectPosition_ : Supported }
+objectPosition_ =
+    Value "object-position"
+
+
+offset_ : Value { provided | offset_ : Supported }
+offset_ =
+    Value "offset"
+
+
+offsetAnchor_ : Value { provided | offsetAnchor_ : Supported }
+offsetAnchor_ =
+    Value "offset-anchor"
+
+
+offsetDistance_ : Value { provided | offsetDistance_ : Supported }
+offsetDistance_ =
+    Value "offset-distance"
+
+
+offsetPath_ : Value { provided | offsetPath_ : Supported }
+offsetPath_ =
+    Value "offset-path"
+
+
+offsetRotate_ : Value { provided | offsetRotate_ : Supported }
+offsetRotate_ =
+    Value "offset-rotate"
+
+
+order_ : Value { provided | order_ : Supported }
+order_ =
+    Value "order"
+
+
+outline_ : Value { provided | outline_ : Supported }
+outline_ =
+    Value "outline"
+
+
+outlineColor_ : Value { provided | outlineColor_ : Supported }
+outlineColor_ =
+    Value "outline-color"
+
+
+outlineOffset_ : Value { provided | outlineOffset_ : Supported }
+outlineOffset_ =
+    Value "outline-offset"
+
+
+outlineWidth_ : Value { provided | outlineWidth_ : Supported }
+outlineWidth_ =
+    Value "outline-width"
+
+
+padding_ : Value { provided | padding_ : Supported }
+padding_ =
+    Value "padding"
+
+
+paddingBottom_ : Value { provided | paddingBottom_ : Supported }
+paddingBottom_ =
+    Value "padding-bottom"
+
+
+paddingLeft_ : Value { provided | paddingLeft_ : Supported }
+paddingLeft_ =
+    Value "padding-left"
+
+
+paddingRight_ : Value { provided | paddingRight_ : Supported }
+paddingRight_ =
+    Value "padding-right"
+
+
+paddingTop_ : Value { provided | paddingTop_ : Supported }
+paddingTop_ =
+    Value "padding-top"
+
+
+tabSize_ : Value { provided | tabSize_ : Supported }
+tabSize_ =
+    Value "tab-size"
+
+
+textIndent_ : Value { provided | textIndent_ : Supported }
+textIndent_ =
+    Value "text-indent"
+
+
+textShadow_ : Value { provided | textShadow_ : Supported }
+textShadow_ =
+    Value "text-shadow"
+
+
+transform_ : Value { provided | transform_ : Supported }
+transform_ =
+    Value "transform"
+
+
+transformOrigin_ : Value { provided | transformOrigin_ : Supported }
+transformOrigin_ =
+    Value "transform-origin"
+
+
+verticalAlign_ : Value { provided | verticalAlign_ : Supported }
+verticalAlign_ =
+    Value "vertical-align"
+
+
+visibility_ : Value { provided | visibility_ : Supported }
+visibility_ =
+    Value "visibility"
+
+
+width_ : Value { provided | width_ : Supported }
+width_ =
+    Value "width"
+
+
+wordSpacing_ : Value { provided | wordSpacing_ : Supported }
+wordSpacing_ =
+    Value "word-spacing"
+
+
+zIndex_ : Value { provided | zIndex_ : Supported }
+zIndex_ =
+    Value "z-index"
+
+
+type alias TransitionBehaviorSupported supported =
+    { supported
+        | allowDiscrete : Supported
+        , normal : Supported
+    }
+
+
+type alias TransitionBehavior =
+    {}
+
+
+allowDiscrete : Value { provides | allowDiscrete : Supported }
+allowDiscrete =
+    Value "allow-discrete"
+
+
+normal : Value { provides | normal : Supported }
+normal =
+    Value "normal"
+
+
+transitionProperty :
+    BaseValue
+        (AnimatableSupported
+            { none : Supported
+            }
+        )
+    -> Style
+transitionProperty (Value val) =
+    appendProperty ("transition-property: " ++ val)
+
+
+transitionDuration : BaseValue Time -> Style
+transitionDuration (Value val) =
+    appendProperty ("transition-duration:" ++ val)
+
+
+transitionDelay : BaseValue Time -> Style
+transitionDelay (Value val) =
+    appendProperty ("transition-delay:" ++ val)
+
+
+transitionBehavior : BaseValue TransitionBehavior -> Style
+transitionBehavior (Value val) =
+    appendProperty ("transition-behavior:" ++ val)
+
+
+transitionTimingFunction : BaseValue EasingFunction -> Style
+transitionTimingFunction (Value val) =
+    appendProperty ("transition-timing-function:" ++ val)
+
+
+type alias TransitionConfig =
+    { property : Value Animatable
+    , easingFunction : Value EasingFunction
+    , duration : Value Time
+    , delay : Value Time
+    , behavior : Value TransitionBehavior
+    }
+
+
+defaultTransition : TransitionConfig
+defaultTransition =
+    { property = all
+    , easingFunction = ease
+    , duration = s 0
+    , delay = s 0
+    , behavior = normal
+    }
+
+
+transition :
+    BaseValue
+        { none : Supported
+        }
+    -> Style
+transition (Value val) =
+    appendProperty ("transition: " ++ val)
+
+
+transitionMany : List TransitionConfig -> Style
+transitionMany configs =
+    let
+        value =
+            case configs of
+                [] ->
+                    "none"
+
+                _ ->
+                    configs
+                        |> List.map transitionConfigToString
+                        |> String.join ", "
+    in
+    appendProperty ("transition:" ++ value)
+
+
+transitionConfigToString : TransitionConfig -> String
+transitionConfigToString config =
+    let
+        (Value property) =
+            config.property
+
+        (Value easingFunction) =
+            config.easingFunction
+
+        (Value duration) =
+            config.duration
+
+        (Value delay) =
+            config.delay
+
+        (Value behavior) =
+            config.behavior
+    in
+    property ++ easingFunction ++ duration ++ delay ++ behavior
 
 
 ------------------------------------------------------------------------

--- a/src/Css.elm
+++ b/src/Css.elm
@@ -20880,7 +20880,7 @@ defaultBoxShadow =
 
     boxShadow none
 
-For defining shadows look at [`boxShadowMany`](#boxShadowMany).
+For defining shadows look at [`boxShadowsMany`](#boxShadowsMany).
 
 -}
 boxShadow : BaseValue { none : Supported } -> Style

--- a/src/Css.elm
+++ b/src/Css.elm
@@ -532,6 +532,7 @@ module Css exposing
     , transitionDelay
     , transitionTimingFunction
     , transitionBehavior
+    , allowDiscrete
     , background_
     , backgroundColor_
     , backgroundPosition_
@@ -556,12 +557,10 @@ module Css exposing
     , borderTopRightRadius_
     , borderTopWidth_
     , borderWidth_
-    , bottom_
     , boxShadow_
     , caretColor_
     , clip_
     , clipPath_
-    , color_
     , columnCount_
     , columnGap_
     , columnRule_
@@ -570,7 +569,6 @@ module Css exposing
     , columnWidth_
     , columns_
     , filter_
-    , flex_
     , flexBasis_
     , flexGrow_
     , flexShrink_
@@ -584,7 +582,6 @@ module Css exposing
     , gridGap_
     , gridRowGap_
     , height_
-    , left_
     , letterSpacing_
     , lineHeight_
     , margin_
@@ -605,7 +602,6 @@ module Css exposing
     , offsetDistance_
     , offsetPath_
     , offsetRotate_
-    , opacity_
     , order_
     , outline_
     , outlineColor_
@@ -616,11 +612,9 @@ module Css exposing
     , paddingLeft_
     , paddingRight_
     , paddingTop_
-    , right_
     , tabSize_
     , textIndent_
     , textShadow_
-    , top_
     , transform_
     , transformOrigin_
     , verticalAlign_
@@ -24634,7 +24628,7 @@ gaps =
 
 type alias AnimatableSupported supported =
     { supported
-        | all : Supported
+        | all_ : Supported
         , background_ : Supported
         , backgroundColor_ : Supported
         , backgroundPosition_ : Supported
@@ -25191,17 +25185,12 @@ type alias TransitionBehaviorSupported supported =
 
 
 type alias TransitionBehavior =
-    {}
+    TransitionBehaviorSupported {}
 
 
 allowDiscrete : Value { provides | allowDiscrete : Supported }
 allowDiscrete =
     Value "allow-discrete"
-
-
-normal : Value { provides | normal : Supported }
-normal =
-    Value "normal"
 
 
 transitionProperty :
@@ -25246,7 +25235,7 @@ type alias TransitionConfig =
 
 defaultTransition : TransitionConfig
 defaultTransition =
-    { property = all
+    { property = all_
     , easingFunction = ease
     , duration = s 0
     , delay = s 0
@@ -25282,7 +25271,7 @@ transitionMany configs =
 transitionConfigToString : TransitionConfig -> String
 transitionConfigToString config =
     let
-        (Value property) =
+        (Value property_) =
             config.property
 
         (Value easingFunction) =
@@ -25297,7 +25286,7 @@ transitionConfigToString config =
         (Value behavior) =
             config.behavior
     in
-    property ++ easingFunction ++ duration ++ delay ++ behavior
+    property_ ++ easingFunction ++ duration ++ delay ++ behavior
 
 
 ------------------------------------------------------------------------

--- a/src/Css.elm
+++ b/src/Css.elm
@@ -521,8 +521,6 @@ module Css exposing
     -- Transitions
     , AnimatableSupported
     , Animatable
-    , TransitionBehaviorSupported
-    , TransitionBehavior
     , TransitionConfig
     , defaultTransition
     , transition
@@ -1662,6 +1660,113 @@ Other values you can use for flex item alignment:
 @docs strokeOrigin
 @docs strokeLinejoin, strokeLinejoin2, crop, arcs, miter, bevel
 @docs strokeDashJustify, compress, dashes, gaps
+
+
+------------------------------------------------------
+
+
+# Transition
+
+@docs Animatable, AnimatableSupported
+@docs TransitionConfig
+@docs defaultTransition
+@docs transition, transitionMany
+@docs transitionProperty
+@docs transitionDuration
+@docs transitionDelay
+@docs transitionTimingFunction
+@docs transitionBehavior
+@docs allowDiscrete
+@docs background_
+@docs backgroundColor_
+@docs backgroundPosition_
+@docs backgroundSize_
+@docs border_
+@docs borderBottom_
+@docs borderBottomColor_
+@docs borderBottomLeftRadius_
+@docs borderBottomRightRadius_
+@docs borderBottomWidth_
+@docs borderColor_
+@docs borderLeft_
+@docs borderLeftColor_
+@docs borderLeftWidth_
+@docs borderRadius_
+@docs borderRight_
+@docs borderRightColor_
+@docs borderRightWidth_
+@docs borderTop_
+@docs borderTopColor_
+@docs borderTopLeftRadius_
+@docs borderTopRightRadius_
+@docs borderTopWidth_
+@docs borderWidth_
+@docs boxShadow_
+@docs caretColor_
+@docs clip_
+@docs clipPath_
+@docs columnCount_
+@docs columnGap_
+@docs columnRule_
+@docs columnRuleColor_
+@docs columnRuleWidth_
+@docs columnWidth_
+@docs columns_
+@docs filter_
+@docs flexBasis_
+@docs flexGrow_
+@docs flexShrink_
+@docs font_
+@docs fontSize_
+@docs fontSizeAdjust_
+@docs fontStretch_
+@docs fontVariationSettings_
+@docs fontWeight_
+@docs gridColumnGap_
+@docs gridGap_
+@docs gridRowGap_
+@docs height_
+@docs letterSpacing_
+@docs lineHeight_
+@docs margin_
+@docs marginBottom_
+@docs marginLeft_
+@docs marginRight_
+@docs marginTop_
+@docs mask_
+@docs maskPosition_
+@docs maskSize_
+@docs maxHeight_
+@docs maxWidth_
+@docs minHeight_
+@docs minWidth_
+@docs objectPosition_
+@docs offset_
+@docs offsetAnchor_
+@docs offsetDistance_
+@docs offsetPath_
+@docs offsetRotate_
+@docs opacity__
+@docs order_
+@docs outline_
+@docs outlineColor_
+@docs outlineOffset_
+@docs outlineWidth_
+@docs padding_
+@docs paddingBottom_
+@docs paddingLeft_
+@docs paddingRight_
+@docs paddingTop_
+@docs tabSize_
+@docs textIndent_
+@docs textShadow_
+@docs transform_
+@docs transformOrigin_
+@docs verticalAlign_
+@docs visibility_
+@docs width_
+@docs wordSpacing_
+@docs zIndex_
 
 
 ------------------------------------------------------
@@ -24732,473 +24837,684 @@ type alias AnimatableSupported supported =
 type alias Animatable =
     AnimatableSupported {}
 
-
+{-| The `background` value used by properties such as [`transition`](#transition),
+and [`transition-property`](#transitionProperty).
+-}
 background_ : Value { provided | background_ : Supported }
 background_ =
     Value "background"
 
-
+{-| The `background-color` value used by properties such as [`transition`](#transition),
+and [`transition-property`](#transitionProperty).
+-}
 backgroundColor_ : Value { provided | backgroundColor_ : Supported }
 backgroundColor_ =
     Value "background-color"
 
-
+{-| The `background-position` value used by properties such as [`transition`](#transition),
+and [`transition-property`](#transitionProperty).
+-}
 backgroundPosition_ : Value { provided | backgroundPosition_ : Supported }
 backgroundPosition_ =
     Value "background-position"
 
-
+{-| The `background-size` value used by properties such as [`transition`](#transition),
+and [`transition-property`](#transitionProperty).
+-}
 backgroundSize_ : Value { provided | backgroundSize_ : Supported }
 backgroundSize_ =
     Value "background-size"
 
-
+{-| The `border` value used by properties such as [`transition`](#transition),
+and [`transition-property`](#transitionProperty).
+-}
 border_ : Value { provided | border_ : Supported }
 border_ =
     Value "border"
 
-
+{-| The `border-bottom` value used by properties such as [`transition`](#transition),
+and [`transition-property`](#transitionProperty).
+-}
 borderBottom_ : Value { provided | borderBottom_ : Supported }
 borderBottom_ =
     Value "border-bottom"
 
-
+{-| The `border-bottom-color` value used by properties such as [`transition`](#transition),
+and [`transition-property`](#transitionProperty).
+-}
 borderBottomColor_ : Value { provided | borderBottomColor_ : Supported }
 borderBottomColor_ =
     Value "border-bottom-color"
 
-
+{-| The `border-bottom-left-radius` value used by properties such as [`transition`](#transition),
+and [`transition-property`](#transitionProperty).
+-}
 borderBottomLeftRadius_ : Value { provided | borderBottomLeftRadius_ : Supported }
 borderBottomLeftRadius_ =
     Value "border-bottom-left-radius"
 
-
+{-| The `border-bottom-right-radius` value used by properties such as [`transition`](#transition),
+and [`transition-property`](#transitionProperty).
+-}
 borderBottomRightRadius_ : Value { provided | borderBottomRightRadius_ : Supported }
 borderBottomRightRadius_ =
     Value "border-bottom-right-radius"
 
-
+{-| The `border-bottom-width` value used by properties such as [`transition`](#transition),
+and [`transition-property`](#transitionProperty).
+-}
 borderBottomWidth_ : Value { provided | borderBottomWidth_ : Supported }
 borderBottomWidth_ =
     Value "border-bottom-width"
 
-
+{-| The `border-color` value used by properties such as [`transition`](#transition),
+and [`transition-property`](#transitionProperty).
+-}
 borderColor_ : Value { provided | borderColor_ : Supported }
 borderColor_ =
     Value "border-color"
 
-
+{-| The `border-left` value used by properties such as [`transition`](#transition),
+and [`transition-property`](#transitionProperty).
+-}
 borderLeft_ : Value { provided | borderLeft_ : Supported }
 borderLeft_ =
     Value "border-left"
 
-
+{-| The `border-left-color` value used by properties such as [`transition`](#transition),
+and [`transition-property`](#transitionProperty).
+-}
 borderLeftColor_ : Value { provided | borderLeftColor_ : Supported }
 borderLeftColor_ =
     Value "border-left-color"
 
-
+{-| The `border-left-width` value used by properties such as [`transition`](#transition),
+and [`transition-property`](#transitionProperty).
+-}
 borderLeftWidth_ : Value { provided | borderLeftWidth_ : Supported }
 borderLeftWidth_ =
     Value "border-left-width"
 
-
+{-| The `border-radius` value used by properties such as [`transition`](#transition),
+and [`transition-property`](#transitionProperty).
+-}
 borderRadius_ : Value { provided | borderRadius_ : Supported }
 borderRadius_ =
     Value "border-radius"
 
-
+{-| The `border-right` value used by properties such as [`transition`](#transition),
+and [`transition-property`](#transitionProperty).
+-}
 borderRight_ : Value { provided | borderRight_ : Supported }
 borderRight_ =
     Value "border-right"
 
-
+{-| The `border-right-color` value used by properties such as [`transition`](#transition),
+and [`transition-property`](#transitionProperty).
+-}
 borderRightColor_ : Value { provided | borderRightColor_ : Supported }
 borderRightColor_ =
     Value "border-right-color"
 
-
+{-| The `border-right-width` value used by properties such as [`transition`](#transition),
+and [`transition-property`](#transitionProperty).
+-}
 borderRightWidth_ : Value { provided | borderRightWidth_ : Supported }
 borderRightWidth_ =
     Value "border-right-width"
 
-
+{-| The `border-top` value used by properties such as [`transition`](#transition),
+and [`transition-property`](#transitionProperty).
+-}
 borderTop_ : Value { provided | borderTop_ : Supported }
 borderTop_ =
     Value "border-top"
 
-
+{-| The `border-top-color` value used by properties such as [`transition`](#transition),
+and [`transition-property`](#transitionProperty).
+-}
 borderTopColor_ : Value { provided | borderTopColor_ : Supported }
 borderTopColor_ =
     Value "border-top-color"
 
-
+{-| The `border-top-left-radius` value used by properties such as [`transition`](#transition),
+and [`transition-property`](#transitionProperty).
+-}
 borderTopLeftRadius_ : Value { provided | borderTopLeftRadius_ : Supported }
 borderTopLeftRadius_ =
     Value "border-top-left-radius"
 
-
+{-| The `border-top-right-radius` value used by properties such as [`transition`](#transition),
+and [`transition-property`](#transitionProperty).
+-}
 borderTopRightRadius_ : Value { provided | borderTopRightRadius_ : Supported }
 borderTopRightRadius_ =
     Value "border-top-right-radius"
 
-
+{-| The `border-top-width` value used by properties such as [`transition`](#transition),
+and [`transition-property`](#transitionProperty).
+-}
 borderTopWidth_ : Value { provided | borderTopWidth_ : Supported }
 borderTopWidth_ =
     Value "border-top-width"
 
-
+{-| The `border-width` value used by properties such as [`transition`](#transition),
+and [`transition-property`](#transitionProperty).
+-}
 borderWidth_ : Value { provided | borderWidth_ : Supported }
 borderWidth_ =
     Value "border-width"
 
-
+{-| The `box-shadow` value used by properties such as [`transition`](#transition),
+and [`transition-property`](#transitionProperty).
+-}
 boxShadow_ : Value { provided | boxShadow_ : Supported }
 boxShadow_ =
     Value "box-shadow"
 
-
+{-| The `caret-color` value used by properties such as [`transition`](#transition),
+and [`transition-property`](#transitionProperty).
+-}
 caretColor_ : Value { provided | caretColor_ : Supported }
 caretColor_ =
     Value "caret-color"
 
-
+{-| The `clip` value used by properties such as [`transition`](#transition),
+and [`transition-property`](#transitionProperty).
+-}
 clip_ : Value { provided | clip_ : Supported }
 clip_ =
     Value "clip"
 
-
+{-| The `clip-path` value used by properties such as [`transition`](#transition),
+and [`transition-property`](#transitionProperty).
+-}
 clipPath_ : Value { provided | clipPath_ : Supported }
 clipPath_ =
     Value "clip-path"
 
-
+{-| The `column-count` value used by properties such as [`transition`](#transition),
+and [`transition-property`](#transitionProperty).
+-}
 columnCount_ : Value { provided | columnCount_ : Supported }
 columnCount_ =
     Value "column-count"
 
-
+{-| The `column-gap` value used by properties such as [`transition`](#transition),
+and [`transition-property`](#transitionProperty).
+-}
 columnGap_ : Value { provided | columnGap_ : Supported }
 columnGap_ =
     Value "column-gap"
 
-
+{-| The `column-rule` value used by properties such as [`transition`](#transition),
+and [`transition-property`](#transitionProperty).
+-}
 columnRule_ : Value { provided | columnRule_ : Supported }
 columnRule_ =
     Value "column-rule"
 
-
+{-| The `column-rule-color` value used by properties such as [`transition`](#transition),
+and [`transition-property`](#transitionProperty).
+-}
 columnRuleColor_ : Value { provided | columnRuleColor_ : Supported }
 columnRuleColor_ =
     Value "column-rule-color"
 
-
+{-| The `column-rule-width` value used by properties such as [`transition`](#transition),
+and [`transition-property`](#transitionProperty).
+-}
 columnRuleWidth_ : Value { provided | columnRuleWidth_ : Supported }
 columnRuleWidth_ =
     Value "column-rule-width"
 
-
+{-| The `column-width` value used by properties such as [`transition`](#transition),
+and [`transition-property`](#transitionProperty).
+-}
 columnWidth_ : Value { provided | columnWidth_ : Supported }
 columnWidth_ =
     Value "column-width"
 
-
+{-| The `columns` value used by properties such as [`transition`](#transition),
+and [`transition-property`](#transitionProperty).
+-}
 columns_ : Value { provided | columns_ : Supported }
 columns_ =
     Value "columns"
 
-
+{-| The `filter` value used by properties such as [`transition`](#transition),
+and [`transition-property`](#transitionProperty).
+-}
 filter_ : Value { provided | filter_ : Supported }
 filter_ =
     Value "filter"
 
-
+{-| The `flex-basis` value used by properties such as [`transition`](#transition),
+and [`transition-property`](#transitionProperty).
+-}
 flexBasis_ : Value { provided | flexBasis_ : Supported }
 flexBasis_ =
     Value "flex-basis"
 
-
+{-| The `flex-grow` value used by properties such as [`transition`](#transition),
+and [`transition-property`](#transitionProperty).
+-}
 flexGrow_ : Value { provided | flexGrow_ : Supported }
 flexGrow_ =
     Value "flex-grow"
 
-
+{-| The `flex-shrink` value used by properties such as [`transition`](#transition),
+and [`transition-property`](#transitionProperty).
+-}
 flexShrink_ : Value { provided | flexShrink_ : Supported }
 flexShrink_ =
     Value "flex-shrink"
 
-
+{-| The `font` value used by properties such as [`transition`](#transition),
+and [`transition-property`](#transitionProperty).
+-}
 font_ : Value { provided | font_ : Supported }
 font_ =
     Value "font"
 
-
+{-| The `font-size` value used by properties such as [`transition`](#transition),
+and [`transition-property`](#transitionProperty).
+-}
 fontSize_ : Value { provided | fontSize_ : Supported }
 fontSize_ =
     Value "font-size"
 
-
+{-| The `font-size-adjust` value used by properties such as [`transition`](#transition),
+and [`transition-property`](#transitionProperty).
+-}
 fontSizeAdjust_ : Value { provided | fontSizeAdjust_ : Supported }
 fontSizeAdjust_ =
     Value "font-size-adjust"
 
-
+{-| The `font-stretch` value used by properties such as [`transition`](#transition),
+and [`transition-property`](#transitionProperty).
+-}
 fontStretch_ : Value { provided | fontStretch_ : Supported }
 fontStretch_ =
     Value "font-stretch"
 
-
+{-| The `font-variation-settings` value used by properties such as [`transition`](#transition),
+and [`transition-property`](#transitionProperty).
+-}
 fontVariationSettings_ : Value { provided | fontVariationSettings_ : Supported }
 fontVariationSettings_ =
     Value "font-variation-settings"
 
-
+{-| The `font-weight` value used by properties such as [`transition`](#transition),
+and [`transition-property`](#transitionProperty).
+-}
 fontWeight_ : Value { provided | fontWeight_ : Supported }
 fontWeight_ =
     Value "font-weight"
 
-
+{-| The `grid-column-gap` value used by properties such as [`transition`](#transition),
+and [`transition-property`](#transitionProperty).
+-}
 gridColumnGap_ : Value { provided | gridColumnGap_ : Supported }
 gridColumnGap_ =
     Value "grid-column-gap"
 
-
+{-| The `grid-gap` value used by properties such as [`transition`](#transition),
+and [`transition-property`](#transitionProperty).
+-}
 gridGap_ : Value { provided | gridGap_ : Supported }
 gridGap_ =
     Value "grid-gap"
 
-
+{-| The `grid-row-gap` value used by properties such as [`transition`](#transition),
+and [`transition-property`](#transitionProperty).
+-}
 gridRowGap_ : Value { provided | gridRowGap_ : Supported }
 gridRowGap_ =
     Value "grid-row-gap"
 
-
+{-| The `height` value used by properties such as [`transition`](#transition),
+and [`transition-property`](#transitionProperty).
+-}
 height_ : Value { provided | height_ : Supported }
 height_ =
     Value "height"
 
-
+{-| The `letter-spacing` value used by properties such as [`transition`](#transition),
+and [`transition-property`](#transitionProperty).
+-}
 letterSpacing_ : Value { provided | letterSpacing_ : Supported }
 letterSpacing_ =
     Value "letter-spacing"
 
-
+{-| The `line-height` value used by properties such as [`transition`](#transition),
+and [`transition-property`](#transitionProperty).
+-}
 lineHeight_ : Value { provided | lineHeight_ : Supported }
 lineHeight_ =
     Value "line-height"
 
-
+{-| The `margin` value used by properties such as [`transition`](#transition),
+and [`transition-property`](#transitionProperty).
+-}
 margin_ : Value { provided | margin_ : Supported }
 margin_ =
     Value "margin"
 
-
+{-| The `margin-bottom` value used by properties such as [`transition`](#transition),
+and [`transition-property`](#transitionProperty).
+-}
 marginBottom_ : Value { provided | marginBottom_ : Supported }
 marginBottom_ =
     Value "margin-bottom"
 
-
+{-| The `margin-left` value used by properties such as [`transition`](#transition),
+and [`transition-property`](#transitionProperty).
+-}
 marginLeft_ : Value { provided | marginLeft_ : Supported }
 marginLeft_ =
     Value "margin-left"
 
-
+{-| The `margin-right` value used by properties such as [`transition`](#transition),
+and [`transition-property`](#transitionProperty).
+-}
 marginRight_ : Value { provided | marginRight_ : Supported }
 marginRight_ =
     Value "margin-right"
 
-
+{-| The `margin-top` value used by properties such as [`transition`](#transition),
+and [`transition-property`](#transitionProperty).
+-}
 marginTop_ : Value { provided | marginTop_ : Supported }
 marginTop_ =
     Value "margin-top"
 
-
+{-| The `mask` value used by properties such as [`transition`](#transition),
+and [`transition-property`](#transitionProperty).
+-}
 mask_ : Value { provided | mask_ : Supported }
 mask_ =
     Value "mask"
 
-
+{-| The `mask-position` value used by properties such as [`transition`](#transition),
+and [`transition-property`](#transitionProperty).
+-}
 maskPosition_ : Value { provided | maskPosition_ : Supported }
 maskPosition_ =
     Value "mask-position"
 
-
+{-| The `mask-size` value used by properties such as [`transition`](#transition),
+and [`transition-property`](#transitionProperty).
+-}
 maskSize_ : Value { provided | maskSize_ : Supported }
 maskSize_ =
     Value "mask-size"
 
-
+{-| The `max-height` value used by properties such as [`transition`](#transition),
+and [`transition-property`](#transitionProperty).
+-}
 maxHeight_ : Value { provided | maxHeight_ : Supported }
 maxHeight_ =
     Value "max-height"
 
-
+{-| The `max-width` value used by properties such as [`transition`](#transition),
+and [`transition-property`](#transitionProperty).
+-}
 maxWidth_ : Value { provided | maxWidth_ : Supported }
 maxWidth_ =
     Value "max-width"
 
 
+{-| The `min-height` value used by properties such as [`transition`](#transition),
+and [`transition-property`](#transitionProperty).
+-}
 minHeight_ : Value { provided | minHeight_ : Supported }
 minHeight_ =
     Value "min-height"
 
 
+{-| The `min-width` value used by properties such as [`transition`](#transition),
+and [`transition-property`](#transitionProperty).
+-}
 minWidth_ : Value { provided | minWidth_ : Supported }
 minWidth_ =
     Value "min-width"
 
 
+{-| The `object-position` value used by properties such as [`transition`](#transition),
+and [`transition-property`](#transitionProperty).
+-}
 objectPosition_ : Value { provided | objectPosition_ : Supported }
 objectPosition_ =
     Value "object-position"
 
 
+{-| The `offset` value used by properties such as [`transition`](#transition),
+and [`transition-property`](#transitionProperty).
+-}
 offset_ : Value { provided | offset_ : Supported }
 offset_ =
     Value "offset"
 
 
+{-| The `offset-anchor` value used by properties such as [`transition`](#transition),
+and [`transition-property`](#transitionProperty).
+-}
 offsetAnchor_ : Value { provided | offsetAnchor_ : Supported }
 offsetAnchor_ =
     Value "offset-anchor"
 
 
+{-| The `offset-distance` value used by properties such as [`transition`](#transition),
+and [`transition-property`](#transitionProperty).
+-}
 offsetDistance_ : Value { provided | offsetDistance_ : Supported }
 offsetDistance_ =
     Value "offset-distance"
 
 
+{-| The `offset-path` value used by properties such as [`transition`](#transition),
+and [`transition-property`](#transitionProperty).
+-}
 offsetPath_ : Value { provided | offsetPath_ : Supported }
 offsetPath_ =
     Value "offset-path"
 
 
+{-| The `offset-rotate` value used by properties such as [`transition`](#transition),
+and [`transition-property`](#transitionProperty).
+-}
 offsetRotate_ : Value { provided | offsetRotate_ : Supported }
 offsetRotate_ =
     Value "offset-rotate"
 
 
+{-| The `opacity` value used by properties such as [`transition`](#transition),
+and [`transition-property`](#transitionProperty).
+-}
 opacity__ : Value { provided | opacity__ : Supported }
 opacity__ =
     Value "opacity"
 
 
+{-| The `order` value used by properties such as [`transition`](#transition),
+and [`transition-property`](#transitionProperty).
+-}
 order_ : Value { provided | order_ : Supported }
 order_ =
     Value "order"
 
 
+{-| The `outline` value used by properties such as [`transition`](#transition),
+and [`transition-property`](#transitionProperty).
+-}
 outline_ : Value { provided | outline_ : Supported }
 outline_ =
     Value "outline"
 
 
+{-| The `outline-color` value used by properties such as [`transition`](#transition),
+and [`transition-property`](#transitionProperty).
+-}
 outlineColor_ : Value { provided | outlineColor_ : Supported }
 outlineColor_ =
     Value "outline-color"
 
 
+{-| The `outline-offset` value used by properties such as [`transition`](#transition),
+and [`transition-property`](#transitionProperty).
+-}
 outlineOffset_ : Value { provided | outlineOffset_ : Supported }
 outlineOffset_ =
     Value "outline-offset"
 
 
+{-| The `outline-width` value used by properties such as [`transition`](#transition),
+and [`transition-property`](#transitionProperty).
+-}
 outlineWidth_ : Value { provided | outlineWidth_ : Supported }
 outlineWidth_ =
     Value "outline-width"
 
 
+{-| The `padding` value used by properties such as [`transition`](#transition),
+and [`transition-property`](#transitionProperty).
+-}
 padding_ : Value { provided | padding_ : Supported }
 padding_ =
     Value "padding"
 
 
+{-| The `padding-bottom` value used by properties such as [`transition`](#transition),
+and [`transition-property`](#transitionProperty).
+-}
 paddingBottom_ : Value { provided | paddingBottom_ : Supported }
 paddingBottom_ =
     Value "padding-bottom"
 
 
+{-| The `padding-left` value used by properties such as [`transition`](#transition),
+and [`transition-property`](#transitionProperty).
+-}
 paddingLeft_ : Value { provided | paddingLeft_ : Supported }
 paddingLeft_ =
     Value "padding-left"
 
 
+{-| The `padding-right` value used by properties such as [`transition`](#transition),
+and [`transition-property`](#transitionProperty).
+-}
 paddingRight_ : Value { provided | paddingRight_ : Supported }
 paddingRight_ =
     Value "padding-right"
 
 
+{-| The `padding-top` value used by properties such as [`transition`](#transition),
+and [`transition-property`](#transitionProperty).
+-}
 paddingTop_ : Value { provided | paddingTop_ : Supported }
 paddingTop_ =
     Value "padding-top"
 
 
+{-| The `tab-size` value used by properties such as [`transition`](#transition),
+and [`transition-property`](#transitionProperty).
+-}
 tabSize_ : Value { provided | tabSize_ : Supported }
 tabSize_ =
     Value "tab-size"
 
 
+{-| The `text-indent` value used by properties such as [`transition`](#transition),
+and [`transition-property`](#transitionProperty).
+-}
 textIndent_ : Value { provided | textIndent_ : Supported }
 textIndent_ =
     Value "text-indent"
 
 
+{-| The `text-shadow` value used by properties such as [`transition`](#transition),
+and [`transition-property`](#transitionProperty).
+-}
 textShadow_ : Value { provided | textShadow_ : Supported }
 textShadow_ =
     Value "text-shadow"
 
 
+{-| The `transform` value used by properties such as [`transition`](#transition),
+and [`transition-property`](#transitionProperty).
+-}
 transform_ : Value { provided | transform_ : Supported }
 transform_ =
     Value "transform"
 
 
+{-| The `transform-origin` value used by properties such as [`transition`](#transition),
+and [`transition-property`](#transitionProperty).
+-}
 transformOrigin_ : Value { provided | transformOrigin_ : Supported }
 transformOrigin_ =
     Value "transform-origin"
 
 
+{-| The `vertical-align` value used by properties such as [`transition`](#transition),
+and [`transition-property`](#transitionProperty).
+-}
 verticalAlign_ : Value { provided | verticalAlign_ : Supported }
 verticalAlign_ =
     Value "vertical-align"
 
 
+{-| The `visibility` value used by properties such as [`transition`](#transition),
+and [`transition-property`](#transitionProperty).
+-}
 visibility_ : Value { provided | visibility_ : Supported }
 visibility_ =
     Value "visibility"
 
 
+{-| The `width` value used by properties such as [`transition`](#transition),
+and [`transition-property`](#transitionProperty).
+-}
 width_ : Value { provided | width_ : Supported }
 width_ =
     Value "width"
 
 
+{-| The `word-spacing` value used by properties such as [`transition`](#transition),
+and [`transition-property`](#transitionProperty).
+-}
 wordSpacing_ : Value { provided | wordSpacing_ : Supported }
 wordSpacing_ =
     Value "word-spacing"
 
 
+{-| The `z-index` value used by properties such as [`transition`](#transition),
+and [`transition-property`](#transitionProperty).
+-}
 zIndex_ : Value { provided | zIndex_ : Supported }
 zIndex_ =
     Value "z-index"
 
 
-type alias TransitionBehaviorSupported supported =
-    { supported
-        | allowDiscrete : Supported
-        , normal : Supported
-    }
-
-
-type alias TransitionBehavior =
-    TransitionBehaviorSupported {}
-
-
+{-| The `allow-discrete` value used by properties such as [`transition`](#transition),
+and [`transition-behavior`](#transitionBehavior).
+-}
 allowDiscrete : Value { provides | allowDiscrete : Supported }
 allowDiscrete =
     Value "allow-discrete"
 
 
+{-| The [`transition-property`](https://css-tricks.com/almanac/properties/t/transition-property/) property.
+
+    transition-property initial
+
+    transition-property none
+
+    transition-property all
+
+    transition-property margin-right
+-}
 transitionProperty :
     BaseValue
         (AnimatableSupported
@@ -25210,45 +25526,97 @@ transitionProperty (Value val) =
     appendProperty ("transition-property:" ++ val)
 
 
-transitionDuration : BaseValue Time -> Style
-transitionDuration (Value val) =
-    appendProperty ("transition-duration:" ++ val)
+{-| The [`transition-timing-function`](https://css-tricks.com/almanac/properties/t/transition-timing-function/) property.
 
+    transition-timing-function ease-out
 
-transitionDelay : BaseValue Time -> Style
-transitionDelay (Value val) =
-    appendProperty ("transition-delay:" ++ val)
-
-
-transitionBehavior : BaseValue TransitionBehavior -> Style
-transitionBehavior (Value val) =
-    appendProperty ("transition-behavior:" ++ val)
-
-
+    transition-timing-function linear
+-}
 transitionTimingFunction : BaseValue EasingFunction -> Style
 transitionTimingFunction (Value val) =
     appendProperty ("transition-timing-function:" ++ val)
 
 
+{-| The [`transition-duration`](https://css-tricks.com/almanac/properties/t/transition-duration/) property.
+
+    transition-duration 2.5s
+
+    transition-duration 400ms
+-}
+transitionDuration : BaseValue Time -> Style
+transitionDuration (Value val) =
+    appendProperty ("transition-duration:" ++ val)
+
+
+{-| The [`transition-delay`](https://css-tricks.com/almanac/properties/t/transition-delay/) property.
+
+    transition-delay 2.5s
+
+    transition-delay 400ms
+-}
+transitionDelay : BaseValue Time -> Style
+transitionDelay (Value val) =
+    appendProperty ("transition-delay:" ++ val)
+
+
+{-| The [`transition-behavior`](https://css-tricks.com/almanac/properties/t/transition-behavior/) property.
+
+    transition-behavior normal
+
+    transition-behavior allowDiscrete
+-}
+transitionBehavior :
+    BaseValue
+        { supported
+            | normal : Supported
+            , allowDiscrete : Supported
+        }
+    -> Style
+transitionBehavior (Value val) =
+    appendProperty ("transition-behavior:" ++ val)
+
+
+{-| Configuration for [`transition`](#transition).
+-}
 type alias TransitionConfig =
     { property : Value Animatable
-    , easingFunction : Value EasingFunction
+    , timingFunction : Value EasingFunction
     , duration : Value Time
     , delay : Value Time
-    , behavior : Value TransitionBehavior
+    , behavior :
+        Value
+            { normal : Supported
+            , allowDiscrete : Supported
+            }
     }
 
 
+{-| Default [`transition`](#transition) configuration.
+
+It is equivalent to the following CSS:
+
+    transition: all ease 0s 0s normal;
+
+-}
 defaultTransition : TransitionConfig
 defaultTransition =
     { property = all_
-    , easingFunction = ease
+    , timingFunction = ease
     , duration = s 0
     , delay = s 0
     , behavior = normal
     }
 
 
+{-| The [`transition`](https://css-tricks.com/almanac/properties/t/transition/) property.
+
+    transition initial
+
+    transition none
+
+For defining transitions look at [`transitionMany`](#transitionMany).
+
+-}
 transition :
     BaseValue
         { none : Supported
@@ -25258,6 +25626,30 @@ transition (Value val) =
     appendProperty ("transition:" ++ val)
 
 
+{-| Sets [`transition`](https://css-tricks.com/almanac/properties/t/transition/).
+
+If you give an empty list, the value will be `none`. This is to make it impossible for it
+to have no values in the output.
+
+    transitionMany [] -- "transition: none"
+
+    -- "transition: margin-right ease-out 4s 2s allow-discrete"
+    button
+        [ css
+            [ transitionMany
+                [ { defaultTransition
+                    | property = marginRight_
+                    , easingFunction = easeOut
+                    , duration = s 4
+                    , delay = s 2
+                    , behavior = allowDiscrete
+                  }
+                ]
+            ]
+        ]
+        [ text "Zap!" ]
+
+-}
 transitionMany : List TransitionConfig -> Style
 transitionMany configs =
     let
@@ -25280,8 +25672,8 @@ transitionConfigToString config =
         (Value property_) =
             config.property
 
-        (Value easingFunction) =
-            config.easingFunction
+        (Value timingFunction) =
+            config.timingFunction
 
         (Value duration) =
             config.duration
@@ -25292,7 +25684,7 @@ transitionConfigToString config =
         (Value behavior) =
             config.behavior
     in
-    property_ ++ " " ++ easingFunction ++ " " ++ duration ++ " " ++ delay ++ " " ++ behavior
+    property_ ++ " " ++ timingFunction ++ " " ++ duration ++ " " ++ delay ++ " " ++ behavior
 
 
 ------------------------------------------------------------------------

--- a/src/Css.elm
+++ b/src/Css.elm
@@ -602,6 +602,7 @@ module Css exposing
     , offsetDistance_
     , offsetPath_
     , offsetRotate_
+    , opacity__
     , order_
     , outline_
     , outlineColor_
@@ -24702,7 +24703,7 @@ type alias AnimatableSupported supported =
         , offsetDistance_ : Supported
         , offsetPath_ : Supported
         , offsetRotate_ : Supported
-        , opacity_ : Supported
+        , opacity__ : Supported
         , order_ : Supported
         , outline_ : Supported
         , outlineColor_ : Supported
@@ -25077,6 +25078,11 @@ offsetRotate_ =
     Value "offset-rotate"
 
 
+opacity__ : Value { provided | opacity__ : Supported }
+opacity__ =
+    Value "opacity"
+
+
 order_ : Value { provided | order_ : Supported }
 order_ =
     Value "order"
@@ -25201,7 +25207,7 @@ transitionProperty :
         )
     -> Style
 transitionProperty (Value val) =
-    appendProperty ("transition-property: " ++ val)
+    appendProperty ("transition-property:" ++ val)
 
 
 transitionDuration : BaseValue Time -> Style
@@ -25249,7 +25255,7 @@ transition :
         }
     -> Style
 transition (Value val) =
-    appendProperty ("transition: " ++ val)
+    appendProperty ("transition:" ++ val)
 
 
 transitionMany : List TransitionConfig -> Style
@@ -25286,7 +25292,7 @@ transitionConfigToString config =
         (Value behavior) =
             config.behavior
     in
-    property_ ++ easingFunction ++ duration ++ delay ++ behavior
+    property_ ++ " " ++ easingFunction ++ " " ++ duration ++ " " ++ delay ++ " " ++ behavior
 
 
 ------------------------------------------------------------------------

--- a/tests/CssTest.elm
+++ b/tests/CssTest.elm
@@ -31,6 +31,7 @@ module CssTest exposing
     , minmax
     , resolution
     , filterFunction
+    , easingFunction
     )
 
 {-| Module for creating large-scale, fully comprehensive CSS function/value tests.
@@ -1518,3 +1519,23 @@ filterFunction =
         
         
         ]
+
+
+easingFunction : List ( Value (EasingFunctionSupported supported), String )
+easingFunction =
+    [ ( linear, "linear" )
+    , ( ease, "ease" )
+    , ( easeIn, "ease-in" )
+    , ( easeOut, "ease-out" )
+    , ( easeInOut, "ease-in-out" )
+    , ( cubicBezier 0.3 2 0.8 5, "cubic-bezier(0.3,2,0.8,5)" )
+    , ( stepStart, "step-start" )
+    , ( stepEnd, "step-end" )
+    , ( steps 4, "steps(4)" )
+    , ( steps2 4 jumpStart, "steps(4,jump-start)" )
+    , ( steps2 4 jumpEnd, "steps(4,jump-end)" )
+    , ( steps2 4 jumpNone, "steps(4,jump-none)" )
+    , ( steps2 4 jumpBoth, "steps(4,jump-both)" )
+    , ( steps2 4 start, "steps(4,start)" )
+    , ( steps2 4 end, "steps(4,end)" )
+    ]

--- a/tests/Specific/Property/Animation.elm
+++ b/tests/Specific/Property/Animation.elm
@@ -36,22 +36,7 @@ all =
 
         , CssTest.property1 animationTimingFunction
             { functionName = "animationTimingFunction", propertyName = "animation-timing-function" }
-            [ ( linear, "linear" )
-            , ( ease, "ease" )
-            , ( easeIn, "ease-in" )
-            , ( easeOut, "ease-out" )
-            , ( easeInOut, "ease-in-out" )
-            , ( cubicBezier 0.3 2 0.8 5, "cubic-bezier(0.3,2,0.8,5)" )
-            , ( stepStart, "step-start" )
-            , ( stepEnd, "step-end" )
-            , ( steps 4, "steps(4)" )
-            , ( steps2 4 jumpStart, "steps(4,jump-start)" )
-            , ( steps2 4 jumpEnd, "steps(4,jump-end)" )
-            , ( steps2 4 jumpNone, "steps(4,jump-none)" )
-            , ( steps2 4 jumpBoth, "steps(4,jump-both)" )
-            , ( steps2 4 start, "steps(4,start)" )
-            , ( steps2 4 end, "steps(4,end)" )
-            ]
+            CssTest.easingFunction
 
         , CssTest.property { functionName = "animationTimingFunctions", propertyName = "animation-timing-function" }
             [ ( animationTimingFunctionMany [ linear, ease, stepEnd ], "linear,ease,step-end" )

--- a/tests/Specific/Property/Transition.elm
+++ b/tests/Specific/Property/Transition.elm
@@ -141,7 +141,7 @@ all =
             , ( transitionMany
                     [ { defaultTransition
                         | property = marginRight_
-                        , easingFunction = easeOut
+                        , timingFunction = easeOut
                         , duration = s 4
                         , delay = s 2
                         , behavior = allowDiscrete

--- a/tests/Specific/Property/Transition.elm
+++ b/tests/Specific/Property/Transition.elm
@@ -1,0 +1,153 @@
+module Specific.Property.Transition exposing (..)
+
+import Css exposing (..)
+import Css.Value exposing (Value(..))
+import CssTest
+import Test exposing (Test)
+
+all : Test
+all =
+    Test.concat
+        [ CssTest.property1 transition
+            { functionName = "transition", propertyName = "transition" }
+            [ ( none, "none" ) ]
+
+        , CssTest.property1 transitionProperty
+            { functionName = "transitionProperty", propertyName = "transition-property" }
+            [ ( none, "none" )
+            , ( all_, "all" )
+            , ( background_, "background" )
+            , ( backgroundColor_, "background-color" )
+            , ( backgroundPosition_, "background-position" )
+            , ( backgroundSize_, "background-size" )
+            , ( border_, "border" )
+            , ( borderBottom_, "border-bottom" )
+            , ( borderBottomColor_, "border-bottom-color" )
+            , ( borderBottomLeftRadius_, "border-bottom-left-radius" )
+            , ( borderBottomRightRadius_, "border-bottom-right-radius" )
+            , ( borderBottomWidth_, "border-bottom-width" )
+            , ( borderColor_, "border-color" )
+            , ( borderLeft_, "border-left" )
+            , ( borderLeftColor_, "border-left-color" )
+            , ( borderLeftWidth_, "border-left-width" )
+            , ( borderRadius_, "border-radius" )
+            , ( borderRight_, "border-right" )
+            , ( borderRightColor_, "border-right-color" )
+            , ( borderRightWidth_, "border-right-width" )
+            , ( borderTop_, "border-top" )
+            , ( borderTopColor_, "border-top-color" )
+            , ( borderTopLeftRadius_, "border-top-left-radius" )
+            , ( borderTopRightRadius_, "border-top-right-radius" )
+            , ( borderTopWidth_, "border-top-width" )
+            , ( borderWidth_, "border-width" )
+            , ( bottom_, "bottom" )
+            , ( boxShadow_, "box-shadow" )
+            , ( caretColor_, "caret-color" )
+            , ( clip_, "clip" )
+            , ( clipPath_, "clip-path" )
+            , ( color_, "color" )
+            , ( columnCount_, "column-count" )
+            , ( columnGap_, "column-gap" )
+            , ( columnRule_, "column-rule" )
+            , ( columnRuleColor_, "column-rule-color" )
+            , ( columnRuleWidth_, "column-rule-width" )
+            , ( columnWidth_, "column-width" )
+            , ( columns_, "columns" )
+            , ( filter_, "filter" )
+            , ( flex_, "flex" )
+            , ( flexBasis_, "flex-basis" )
+            , ( flexGrow_, "flex-grow" )
+            , ( flexShrink_, "flex-shrink" )
+            , ( font_, "font" )
+            , ( fontSize_, "font-size" )
+            , ( fontSizeAdjust_, "font-size-adjust" )
+            , ( fontStretch_, "font-stretch" )
+            , ( fontVariationSettings_, "font-variation-settings" )
+            , ( fontWeight_, "font-weight" )
+            , ( gridColumnGap_, "grid-column-gap" )
+            , ( gridGap_, "grid-gap" )
+            , ( gridRowGap_, "grid-row-gap" )
+            , ( height_, "height" )
+            , ( left_, "left" )
+            , ( letterSpacing_, "letter-spacing" )
+            , ( lineHeight_, "line-height" )
+            , ( margin_, "margin" )
+            , ( marginBottom_, "margin-bottom" )
+            , ( marginLeft_, "margin-left" )
+            , ( marginRight_, "margin-right" )
+            , ( marginTop_, "margin-top" )
+            , ( mask_, "mask" )
+            , ( maskPosition_, "mask-position" )
+            , ( maskSize_, "mask-size" )
+            , ( maxHeight_, "max-height" )
+            , ( maxWidth_, "max-width" )
+            , ( minHeight_, "min-height" )
+            , ( minWidth_, "min-width" )
+            , ( objectPosition_, "object-position" )
+            , ( offset_, "offset" )
+            , ( offsetAnchor_, "offset-anchor" )
+            , ( offsetDistance_, "offset-distance" )
+            , ( offsetPath_, "offset-path" )
+            , ( offsetRotate_, "offset-rotate" )
+            , ( opacity__, "opacity" )
+            , ( order_, "order" )
+            , ( outline_, "outline" )
+            , ( outlineColor_, "outline-color" )
+            , ( outlineOffset_, "outline-offset" )
+            , ( outlineWidth_, "outline-width" )
+            , ( padding_, "padding" )
+            , ( paddingBottom_, "padding-bottom" )
+            , ( paddingLeft_, "padding-left" )
+            , ( paddingRight_, "padding-right" )
+            , ( paddingTop_, "padding-top" )
+            , ( right_, "right" )
+            , ( tabSize_, "tab-size" )
+            , ( textIndent_, "text-indent" )
+            , ( textShadow_, "text-shadow" )
+            , ( top_, "top" )
+            , ( transform_, "transform" )
+            , ( transformOrigin_, "transform-origin" )
+            , ( verticalAlign_, "vertical-align" )
+            , ( visibility_, "visibility" )
+            , ( width_, "width" )
+            , ( wordSpacing_, "word-spacing" )
+            , ( zIndex_, "z-index" )
+            ]
+
+        , CssTest.property1 transitionDuration
+            { functionName = "transitionDuration", propertyName = "transition-duration" }
+            CssTest.time
+
+        , CssTest.property1 transitionDelay
+            { functionName = "transitionDelay", propertyName = "transition-delay" }
+            CssTest.time
+
+        , CssTest.property1 transitionBehavior
+            { functionName = "transitionBehavior", propertyName = "transition-behavior" }
+            [ ( allowDiscrete, "allow-discrete" )
+            , ( normal, "normal" )
+            ]
+
+        , CssTest.property1 transitionTimingFunction
+            { functionName = "transitionTimingFunction", propertyName = "transition-timing-function" }
+            CssTest.easingFunction
+
+        , CssTest.property
+            { functionName = "transitionMany", propertyName = "transition" }
+            [ ( transitionMany [], "none" )
+            , ( transitionMany [ defaultTransition ]
+              , "all ease 0s 0s normal"
+              )
+            , ( transitionMany
+                    [ { defaultTransition
+                        | property = marginRight_
+                        , easingFunction = easeOut
+                        , duration = s 4
+                        , delay = s 2
+                        , behavior = allowDiscrete
+                      }
+                    ]
+              , "margin-right ease-out 4s 2s allow-discrete"
+              )
+            ]
+        ]


### PR DESCRIPTION
This PR adds the `transition-*` properties as well as a `transitionMany` for multiple transition definitions.

Also, would you be open to a PR that runs elm-format and/or elm-review on the whole library? formatting by hand is quite a pain now that I'm used to autoformatting.