### PR TITLE
fix boxShadowMany link in doc

### DIFF
--- a/src/Css.elm
+++ b/src/Css.elm
@@ -20774,7 +20774,7 @@ defaultBoxShadow =
 
     boxShadow none
 
-For defining shadows look at [`boxShadowsMany`](#boxShadowsMany).
+For defining shadows look at [`boxShadowMany`](#boxShadowMany).
 
 -}
 boxShadow : BaseValue { none : Supported } -> Style


### PR DESCRIPTION
There was a typo in the link to `boxShadowMany` in the doc of `boxShadow`